### PR TITLE
Update Gradle CI workflow for wrapper checks and coverage

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,8 +26,11 @@ jobs:
         working-directory:  ${{ github.workspace }}/.github
         run: ./run-checks.sh
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
+      - name: Sanity check Gradle wrapper files
+        run: |
+          test -f gradlew
+          test -f gradle/wrapper/gradle-wrapper.properties
+          test -f gradle/wrapper/gradle-wrapper.jar
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4
@@ -39,8 +42,11 @@ jobs:
       - name: Build and check with Gradle
         run: ./gradlew check coverage
 
-      - name: Upload coverage reports to Codecov
+      - name: Upload coverage reports (artifact)
         if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v4
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-reports
+          path: |
+            build/reports
+            build/test-results


### PR DESCRIPTION
Replaced Gradle wrapper validation action with sanity checks for wrapper files. Updated coverage report upload to use artifact upload instead of Codecov.